### PR TITLE
Centered Figures FTW!

### DIFF
--- a/content/experiments/This sounds Turkish to me.rst
+++ b/content/experiments/This sounds Turkish to me.rst
@@ -277,16 +277,9 @@ Surprisingly, this is NOT what happened: in fact, **our Turkish participants sho
 So this is where we are now. Despite disprefering plural subjects with plural verbs, Turkish speakers are still susceptible to attraction errors in comprehension. To us, this means that attraction errors in comprehension do not occur simply because people hear these errors often in production (although admittedly, we haven't tested whether Turkish people produce attraction errors yet). More generally, our results suggest that attraction errors in production and in comprehension might not obey the same principles, which is an intriguing possibility. But then, what causes attraction in comprehension? This, I think, will be a harder question to answer. Stay tuned for updates!
 
 .. figure:: {filename}/images/ankara_end.png
-  :width: 100%
-  :figwidth: 35%
   :align: center
   :alt: ankara_end
-  
 
-  
+  ..
 
-
-
-  
-
-  
+  My last Ankara dinner. After running 71 Turkish speakers in 5 days, we decided that we deserved a drink

--- a/themes/twenty/static/css/style.css
+++ b/themes/twenty/static/css/style.css
@@ -1108,7 +1108,7 @@
 
 	/* Figure styling */
 	.legend {
-		background-color: #F5F5F5;
+		background-color: #d9d9d9;
 		font-style: italic;
 		font-size: .7em;
 		margin-top: 1em;

--- a/themes/twenty/static/css/style.css
+++ b/themes/twenty/static/css/style.css
@@ -1110,6 +1110,7 @@
 	.legend {
 		background-color: #F5F5F5;
 		font-style: italic;
+		font-size: .7em;
 		margin-top: 1em;
 		padding: 0 1em;
 		text-align: justify;

--- a/themes/twenty/static/css/style.css
+++ b/themes/twenty/static/css/style.css
@@ -1096,9 +1096,14 @@
 	}
 
 	/*Centered images don't get wrapped. */
-	img[align=center], .align-center img, img.align-center {
+	img[align=center], img.align-center {
 		margin: 2em auto;
 		display: block;
+	}
+	.figure.align-center {
+		margin: 2em auto;
+		display: table;
+		text-align: center;
 	}
 
 	/* Figure styling */
@@ -1108,6 +1113,11 @@
 		margin-top: 1em;
 		padding: 0 1em;
 		text-align: justify;
+	}
+
+	.align-center .legend {
+		display: table-caption;
+		caption-side: bottom;
 	}
 
 

--- a/themes/twenty/static/css/style.css
+++ b/themes/twenty/static/css/style.css
@@ -1107,6 +1107,7 @@
 		font-style: italic;
 		margin-top: 1em;
 		padding: 0 1em;
+		text-align: justify;
 	}
 
 

--- a/themes/twenty/templates/base.html
+++ b/themes/twenty/templates/base.html
@@ -87,7 +87,7 @@
 
       <span class="copyright">
         &copy 2016 Sol Lago.
-        Design: Ilia Kurenkov based on <a href="http://html5up.net/twenty">Twenty by HTML5 UP</a>.
+        Design: Ilia Kurenkov based on <a href="http://html5up.net/twenty">Twenty</a>.
       </span>
 
   </footer>

--- a/themes/twenty/templates/category.html
+++ b/themes/twenty/templates/category.html
@@ -19,7 +19,7 @@
         </div>
         <div class="4u">
           <header>
-            <h3>Other {{ category }}</h3>
+            <h3>Past Posts</h3>
           </header>
           <!-- Sidebar -->
           <div class="sidebar">

--- a/themes/twenty/templates/homepage.html
+++ b/themes/twenty/templates/homepage.html
@@ -41,7 +41,7 @@
         {{ render_articles("News", news) }}
       </div>
       <div class="5u -2u">
-        {{ render_articles("Recent Experiments", experiments) }}
+        {{ render_articles("Experiment Posts", experiments) }}
         <footer class="button-block">
             <div class="special">
               <a href="{{ SITEURL }}/category/experiments" class="button small">Read More</a>


### PR DESCRIPTION
This, I hope, fixes the display of centered figures so that the images are square in the middle of the page and the legend is correctly aligned with it.

There are also some minor tweaks to the legend text: it's justified, as per request. And I thought it may look better if we make it a tad bit smaller than regular text, because this is something I seem to remember seeing in books and papers. I have also made the background darker. If you are unhappy with it, please save everyone some time and pick a color you like then send me the html code for it.
