### PR TITLE
Relaxed version requirements in conda_environment.yaml

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,15 +1,15 @@
 name: sol_site
 dependencies:
-- openssl=1.0.2d=0
+- openssl
 - pip
-- python=3.4.3=2
-- readline=6.2=2
-- setuptools=18.5=py34_0
-- sqlite=3.8.4.1=1
-- tk=8.5.18=0
-- wheel=0.26.0=py34_1
-- xz=5.0.5=0
-- zlib=1.2.8=0
+- python=3
+- readline
+- setuptools
+- sqlite
+- tk
+- wheel
+- xz
+- zlib
 - pip:
   - blinker==1.4
   - docutils==0.12


### PR DESCRIPTION
After you merge this change, you'll have to delete and recreate the conda environment:

1. run `conda remove --name sol_site --all`
2. then recreate the environment as in the readme: `conda env create -f conda_environment.yml`

However, I also discovered [this thread](http://stackoverflow.com/questions/19961239/pelican-3-3-pelican-quickstart-error-valueerror-unknown-locale-utf-8), which suggests that the problem is just somehow between python 3 and MacOS Mavericks. Even if that's the case, though, this change is an improvement over what we had before.